### PR TITLE
Add runtime key/information

### DIFF
--- a/src/main/java/com/iopipe/IOpipeMeasurement.java
+++ b/src/main/java/com/iopipe/IOpipeMeasurement.java
@@ -25,12 +25,12 @@ import javax.json.stream.JsonGenerator;
  * @since 2017/12/15
  */
 public final class IOpipeMeasurement
-{	
+{
 	/** Is this a Linux system? */
 	private static final boolean _IS_LINUX =
 		"linux".compareToIgnoreCase(
 			System.getProperty("os.name", "unknown")) == 0;
-	
+
 	/** The system properties to copy in the environment report. */
 	private static final List<String> _COPY_PROPERTIES =
 		Collections.<String>unmodifiableList(Arrays.<String>asList(
@@ -42,23 +42,23 @@ public final class IOpipeMeasurement
 			"java.specification.name", "java.class.version",
 			"java.compiler", "os.name", "os.arch", "os.version",
 			"file.separator", "path.separator"));
-	
+
 	/** The configuration. */
 	protected final IOpipeConfiguration config;
-	
+
 	/** The context this is taking the measurement for. */
 	protected final Context context;
-	
+
 	/** The exception which may have been thrown. */
 	private volatile Throwable _thrown;
-	
+
 	/** The duration of execution in nanoseconds. */
 	private volatile long _duration =
 		Long.MIN_VALUE;
-	
+
 	/** Is this execution one which is a cold start? */
 	private volatile boolean _coldstart;
-	
+
 	/**
 	 * Initializes the measurement holder.
 	 *
@@ -72,11 +72,11 @@ public final class IOpipeMeasurement
 	{
 		if (__config == null || __context == null)
 			throw new NullPointerException();
-		
+
 		this.config = __config;
 		this.context = __context;
 	}
-	
+
 	/**
 	 * Builds the request which is sent to the remote service.
 	 *
@@ -89,31 +89,31 @@ public final class IOpipeMeasurement
 	{
 		Context aws = this.context;
 		IOpipeConfiguration config = this.config;
-		
+
 		// Snapshot system information
 		SystemMeasurement sysinfo = new SystemMeasurement();
-		
+
 		StringWriter out = new StringWriter();
 		try (JsonGenerator gen = Json.createGenerator(out))
 		{
 			gen.writeStartObject();
-			
+
 			gen.write("client_id", config.getProjectToken());
 			// UNUSED: "projectId": "s"
 			gen.write("installMethod",
 				Objects.toString(config.getInstallMethod(), "unknown"));
-			
+
 			long duration = this._duration;
 			if (duration >= 0)
 				gen.write("duration", duration);
-			
+
 			gen.write("processId", sysinfo.pid);
 			gen.write("timestamp", IOpipeConstants.LOAD_TIME);
 			gen.write("timestampEnd", System.currentTimeMillis());
-			
+
 			// AWS Context information
 			gen.writeStartObject("aws");
-			
+
 			gen.write("functionName", aws.getFunctionName());
 			gen.write("functionVersion", aws.getFunctionVersion());
 			gen.write("awsRequestId", aws.getAwsRequestId());
@@ -125,160 +125,162 @@ public final class IOpipeMeasurement
 				aws.getRemainingTimeInMillis());
 			gen.write("traceId", Objects.toString(
 				System.getenv("_X_AMZN_TRACE_ID"), "unknown"));
-			
+
 			gen.writeEnd();
-			
+
 			// Memory Usage -- UNUSED
 			/*gen.writeStartObject("memory");
-			
+
 			gen.write("rssMiB", );
 			gen.write("totalMiB", );
 			gen.write("rssTotalPercentage", );
-			
+
 			gen.writeEnd();*/
-			
+
 			// Environment start
 			gen.writeStartObject("environment");
-			
+
 			// Agent
 			gen.writeStartObject("agent");
-			
+
 			gen.write("runtime", "java");
 			gen.write("version", IOpipeConstants.AGENT_VERSION);
 			gen.write("load_time", IOpipeConstants.LOAD_TIME);
-			
+
 			gen.writeEnd();
-			
-			// Java information
-			gen.writeStartObject("java");
-			
-			for (String prop : IOpipeMeasurement._COPY_PROPERTIES)
-				gen.write(prop, System.getProperty(prop, ""));
-			
+
+			// Runtime information
+			gen.writeStartObject("runtime");
+			gen.write("name", "java");
+			gen.write("version", System.getProperty("java.version", ""));
 			gen.writeEnd();
-			
+			//
+			// for (String prop : IOpipeMeasurement._COPY_PROPERTIES)
+			// 	gen.write(prop, System.getProperty(prop, ""));
+			//
+
 			// Unique operating system boot identifier
 			gen.writeStartObject("host");
-			
+
 			gen.write("boot_id", SystemMeasurement.BOOTID);
-			
+
 			gen.writeEnd();
-			
+
 			// Operating System Start
 			gen.writeStartObject("os");
-			
+
 			long totalmem, freemem;
 			gen.write("hostname", SystemMeasurement.HOSTNAME);
 			gen.write("totalmem", (totalmem = sysinfo.memorytotalkib));
 			gen.write("freemem", (freemem = sysinfo.memoryfreekib));
 			gen.write("usedmem", totalmem - freemem);
-			
+
 			// Start CPUs
 			gen.writeStartArray("cpus");
-			
+
 			List<SystemMeasurement.Cpu> cpus = sysinfo.cpus;
 			for (int i = 0, n = cpus.size(); i < n; i++)
 			{
 				SystemMeasurement.Cpu cpu = cpus.get(i);
-				
+
 				gen.writeStartObject();
 				gen.writeStartObject("times");
-				
+
 				gen.write("idle", cpu.idle);
 				gen.write("irq", cpu.irq);
 				gen.write("sys", cpu.sys);
 				gen.write("user", cpu.user);
 				gen.write("nice", cpu.nice);
-				
+
 				gen.writeEnd();
 				gen.writeEnd();
 			}
-			
+
 			// End CPUs
 			gen.writeEnd();
-			
+
 			// Linux information
 			if (_IS_LINUX)
 			{
 				// Start Linux
 				gen.writeStartObject("linux");
-				
+
 				// Start PID
 				gen.writeStartObject("pid");
-				
+
 				// Start self
 				gen.writeStartObject("self");
-				
+
 				gen.writeStartObject("stat");
-				
+
 				SystemMeasurement.Times times = new SystemMeasurement.Times();
 				gen.write("utime", times.utime);
 				gen.write("stime", times.stime);
 				gen.write("cutime", times.cutime);
 				gen.write("cstime", times.cstime);
-				
+
 				gen.writeEnd();
-				
+
 				gen.writeStartObject("stat_start");
-				
+
 				times = IOpipeService._STAT_START;
 				gen.write("utime", times.utime);
 				gen.write("stime", times.stime);
 				gen.write("cutime", times.cutime);
 				gen.write("cstime", times.cstime);
-				
+
 				gen.writeEnd();
-				
+
 				gen.writeStartObject("status");
-				
+
 				gen.write("VmRSS", sysinfo.vmrsskib);
 				gen.write("Threads", sysinfo.threads);
 				gen.write("FDSize", sysinfo.fdsize);
-				
+
 				gen.writeEnd();
-				
+
       			// End self
       			gen.writeEnd();
-				
+
 				// End PID
 				gen.writeEnd();
-				
+
 				// End Linux
 				gen.writeEnd();
 			}
-			
+
 			// Operating System end
 			gen.writeEnd();
-			
+
 			// Environment end
 			gen.writeEnd();
-			
+
 			Throwable thrown = this._thrown;
 			if (thrown != null)
 			{
 				gen.writeStartObject("errors");
-				
+
 				// Write the stack as if it were normally output on the console
 				StringWriter trace = new StringWriter();
 				try (PrintWriter pw = new PrintWriter(trace))
 				{
 					thrown.printStackTrace(pw);
-			
+
 					pw.flush();
 				}
-				
+
 				gen.write("stack", trace.toString());
 				gen.write("name", thrown.getClass().getName());
 				gen.write("message",
 					Objects.toString(thrown.getMessage(), ""));
 				// UNUSED: "stackHash": "s",
 				// UNUSED: "count": "n"
-				
+
 				gen.writeEnd();
 			}
-			
+
 			gen.write("coldstart", this._coldstart);
-			
+
 			// Finished
 			gen.writeEnd();
 			gen.flush();
@@ -287,10 +289,10 @@ public final class IOpipeMeasurement
 		{
 			throw new RemoteException("Could not build request", e);
 		}
-		
+
 		return new RemoteRequest(out.toString());
 	}
-	
+
 	/**
 	 * Returns the execution duration.
 	 *
@@ -302,7 +304,7 @@ public final class IOpipeMeasurement
 	{
 		return this._duration;
 	}
-	
+
 	/**
 	 * Returns the thrown throwable.
 	 *
@@ -314,7 +316,7 @@ public final class IOpipeMeasurement
 	{
 		return this._thrown;
 	}
-	
+
 	/**
 	 * Sets whether or not the execution was a cold start. A cold start
 	 * indicates that the JVM was started fresh and a previous instance is not
@@ -327,7 +329,7 @@ public final class IOpipeMeasurement
 	{
 		this._coldstart = __cold;
 	}
-	
+
 	/**
 	 * Sets the duration of execution.
 	 *
@@ -338,7 +340,7 @@ public final class IOpipeMeasurement
 	{
 		this._duration = __ns;
 	}
-	
+
 	/**
 	 * Sets the throwable generated during execution.
 	 *
@@ -350,4 +352,3 @@ public final class IOpipeMeasurement
 		this._thrown = __t;
 	}
 }
-

--- a/src/main/java/com/iopipe/IOpipeMeasurement.java
+++ b/src/main/java/com/iopipe/IOpipeMeasurement.java
@@ -31,18 +31,6 @@ public final class IOpipeMeasurement
 		"linux".compareToIgnoreCase(
 			System.getProperty("os.name", "unknown")) == 0;
 
-	/** The system properties to copy in the environment report. */
-	private static final List<String> _COPY_PROPERTIES =
-		Collections.<String>unmodifiableList(Arrays.<String>asList(
-			"java.version", "java.vendor", "java.vendor.url",
-			"java.vm.specification.version",
-			"java.vm.specification.vendor", "java.vm.specification.name",
-			"java.vm.version", "java.vm.vendor", "java.vm.name",
-			"java.specification.version", "java.specification.vendor",
-			"java.specification.name", "java.class.version",
-			"java.compiler", "os.name", "os.arch", "os.version",
-			"file.separator", "path.separator"));
-
 	/** The configuration. */
 	protected final IOpipeConfiguration config;
 
@@ -142,11 +130,9 @@ public final class IOpipeMeasurement
 
 			// Agent
 			gen.writeStartObject("agent");
-
 			gen.write("runtime", "java");
 			gen.write("version", IOpipeConstants.AGENT_VERSION);
 			gen.write("load_time", IOpipeConstants.LOAD_TIME);
-
 			gen.writeEnd();
 
 			// Runtime information
@@ -154,10 +140,6 @@ public final class IOpipeMeasurement
 			gen.write("name", "java");
 			gen.write("version", System.getProperty("java.version", ""));
 			gen.writeEnd();
-			//
-			// for (String prop : IOpipeMeasurement._COPY_PROPERTIES)
-			// 	gen.write(prop, System.getProperty(prop, ""));
-			//
 
 			// Unique operating system boot identifier
 			gen.writeStartObject("host");

--- a/src/main/java/com/iopipe/IOpipeMeasurement.java
+++ b/src/main/java/com/iopipe/IOpipeMeasurement.java
@@ -139,6 +139,9 @@ public final class IOpipeMeasurement
 			gen.writeStartObject("runtime");
 			gen.write("name", "java");
 			gen.write("version", System.getProperty("java.version", ""));
+			gen.write("vendor", System.getProperty("java.vendor", ""));
+			gen.write("vmVendor", System.getProperty("java.vm.vendor", ""));
+			gen.write("vmVersion", System.getProperty("java.vm.version", ""));
 			gen.writeEnd();
 
 			// Unique operating system boot identifier


### PR DESCRIPTION
Per update to the [schema](https://github.com/iopipe/iopipe-js-core/blob/master/src/schema.json), change the java key to the more generalized runtime key. Apologies that my editor made a bunch of whitespace updates.

Q: Should we remove the COPY_PROPERTIES List? Seems possibly useful later on.